### PR TITLE
Use a `Cell<Option<T>>` to cache the model matrices, instead of a boolean `requires_update` flag

### DIFF
--- a/docs/section_9.md
+++ b/docs/section_9.md
@@ -61,7 +61,7 @@ I created a new module named `obj_loader` where I added code related to loading 
 
 #### Vertices
 
-Like I mentioned in the other section, I've created new vertex types and moved them to `obj_vector`.
+Like I mentioned in the other section, I've created new vertex types and moved them to `obj_loader`.
 
 For the purpose of this lesson, we'll be using a type named `NormalVertex`. This is the same as the `Vertex` type we used in the last lesson, just with a more descriptive name. So go through your code and rename instances of `Vertex` with `NormalVertex`.
 

--- a/lessons/10. Uniform Refactoring/src/model.rs
+++ b/lessons/10. Uniform Refactoring/src/model.rs
@@ -6,6 +6,7 @@
 use super::obj_loader::{Loader, NormalVertex};
 
 use nalgebra_glm::{identity, inverse_transpose, rotate_normalized_axis, translate, TMat4, TVec3};
+use std::cell::Cell;
 
 /// Holds our data for a renderable model, including the model matrix data
 ///
@@ -17,12 +18,19 @@ pub struct Model {
     data: Vec<NormalVertex>,
     translation: TMat4<f32>,
     rotation: TMat4<f32>,
+
+    // We might call multiple translation/rotation calls
+    // in between asking for the model matrix. This lets us
+    // only recreate the model matrices when needed.
+    // Use a Cell with the interior mutability pattern,
+    // so that it can be modified by methods that don't take &mut self
+    cache: Cell<Option<ModelMatrices>>,
+}
+
+#[derive(Copy, Clone)]
+struct ModelMatrices {
     model: TMat4<f32>,
     normals: TMat4<f32>,
-    // we might call multiple translation/rotation calls
-    // in between asking for the model matrix. This lets
-    // only recreate the model matrix when needed.
-    requires_update: bool,
 }
 
 pub struct ModelBuilder {
@@ -46,9 +54,7 @@ impl ModelBuilder {
             data: loader.as_normal_vertices(),
             translation: identity(),
             rotation: identity(),
-            model: identity(),
-            normals: identity(),
-            requires_update: false,
+            cache: Cell::new(None),
         }
     }
 
@@ -77,28 +83,33 @@ impl Model {
         self.data.clone()
     }
 
-    pub fn model_matrices(&mut self) -> (TMat4<f32>, TMat4<f32>) {
-        if self.requires_update {
-            self.model = self.translation * self.rotation;
-            self.normals = inverse_transpose(self.model);
-            self.requires_update = false;
+    pub fn model_matrices(&self) -> (TMat4<f32>, TMat4<f32>) {
+        if let Some(cache) = self.cache.get() {
+            return (cache.model, cache.normals);
         }
-        (self.model, self.normals)
+
+        // recalculate matrices
+        let model = self.translation * self.rotation;
+        let normals = inverse_transpose(model);
+
+        self.cache.set(Some(ModelMatrices { model, normals }));
+
+        (model, normals)
     }
 
     pub fn rotate(&mut self, radians: f32, v: TVec3<f32>) {
         self.rotation = rotate_normalized_axis(&self.rotation, radians, &v);
-        self.requires_update = true;
+        self.cache.set(None);
     }
 
     pub fn translate(&mut self, v: TVec3<f32>) {
         self.translation = translate(&self.translation, &v);
-        self.requires_update = true;
+        self.cache.set(None);
     }
 
     /// Return the model's rotation to 0
     pub fn zero_rotation(&mut self) {
         self.rotation = identity();
-        self.requires_update = true;
+        self.cache.set(None);
     }
 }

--- a/lessons/11. First Rendering System/src/main.rs
+++ b/lessons/11. First Rendering System/src/main.rs
@@ -88,9 +88,9 @@ fn main() {
             torus.rotate(elapsed_as_radians as f32 * 12.0, vec3(1.0, 0.0, 0.0));
 
             system.start();
-            system.geometry(&mut teapot);
-            system.geometry(&mut suzanne);
-            system.geometry(&mut torus);
+            system.geometry(&teapot);
+            system.geometry(&suzanne);
+            system.geometry(&torus);
             system.ambient();
             system.directional(&directional_light_r);
             system.directional(&directional_light_g);

--- a/lessons/11. First Rendering System/src/model.rs
+++ b/lessons/11. First Rendering System/src/model.rs
@@ -6,6 +6,7 @@
 use super::obj_loader::{Loader, NormalVertex};
 
 use nalgebra_glm::{identity, inverse_transpose, rotate_normalized_axis, translate, TMat4, TVec3};
+use std::cell::Cell;
 
 /// Holds our data for a renderable model, including the model matrix data
 ///
@@ -17,12 +18,19 @@ pub struct Model {
     data: Vec<NormalVertex>,
     translation: TMat4<f32>,
     rotation: TMat4<f32>,
+
+    // We might call multiple translation/rotation calls
+    // in between asking for the model matrix. This lets us
+    // only recreate the model matrices when needed.
+    // Use a Cell with the interior mutability pattern,
+    // so that it can be modified by methods that don't take &mut self
+    cache: Cell<Option<ModelMatrices>>,
+}
+
+#[derive(Copy, Clone)]
+struct ModelMatrices {
     model: TMat4<f32>,
     normals: TMat4<f32>,
-    // we might call multiple translation/rotation calls
-    // in between asking for the model matrix. This lets
-    // only recreate the model matrix when needed.
-    requires_update: bool,
 }
 
 pub struct ModelBuilder {
@@ -46,9 +54,7 @@ impl ModelBuilder {
             data: loader.as_normal_vertices(),
             translation: identity(),
             rotation: identity(),
-            model: identity(),
-            normals: identity(),
-            requires_update: false,
+            cache: Cell::new(None),
         }
     }
 
@@ -77,28 +83,33 @@ impl Model {
         self.data.clone()
     }
 
-    pub fn model_matrices(&mut self) -> (TMat4<f32>, TMat4<f32>) {
-        if self.requires_update {
-            self.model = self.translation * self.rotation;
-            self.normals = inverse_transpose(self.model);
-            self.requires_update = false;
+    pub fn model_matrices(&self) -> (TMat4<f32>, TMat4<f32>) {
+        if let Some(cache) = self.cache.get() {
+            return (cache.model, cache.normals);
         }
-        (self.model, self.normals)
+
+        // recalculate matrices
+        let model = self.translation * self.rotation;
+        let normals = inverse_transpose(model);
+
+        self.cache.set(Some(ModelMatrices { model, normals }));
+
+        (model, normals)
     }
 
     pub fn rotate(&mut self, radians: f32, v: TVec3<f32>) {
         self.rotation = rotate_normalized_axis(&self.rotation, radians, &v);
-        self.requires_update = true;
+        self.cache.set(None);
     }
 
     pub fn translate(&mut self, v: TVec3<f32>) {
         self.translation = translate(&self.translation, &v);
-        self.requires_update = true;
+        self.cache.set(None);
     }
 
     /// Return the model's rotation to 0
     pub fn zero_rotation(&mut self) {
         self.rotation = identity();
-        self.requires_update = true;
+        self.cache.set(None);
     }
 }

--- a/lessons/11. First Rendering System/src/system/system.rs
+++ b/lessons/11. First Rendering System/src/system/system.rs
@@ -669,7 +669,7 @@ impl System {
         pool.from_data(uniform_data).unwrap()
     }
 
-    pub fn geometry(&mut self, model: &mut Model) {
+    pub fn geometry(&mut self, model: &Model) {
         match self.render_stage {
             RenderStage::Deferred => {}
             RenderStage::NeedsRedraw => {

--- a/lessons/11.5. Light Objects/src/main.rs
+++ b/lessons/11.5. Light Objects/src/main.rs
@@ -68,7 +68,7 @@ fn main() {
             let directional_light = DirectionalLight::new([x, 0.0, z, 1.0], [1.0, 1.0, 1.0]);
 
             system.start();
-            system.geometry(&mut sphere);
+            system.geometry(&sphere);
             system.ambient();
             system.directional(&directional_light);
             system.light_object(&directional_light);

--- a/lessons/11.5. Light Objects/src/system/system.rs
+++ b/lessons/11.5. Light Objects/src/system/system.rs
@@ -709,7 +709,7 @@ impl System {
         pool.from_data(uniform_data).unwrap()
     }
 
-    pub fn geometry(&mut self, model: &mut Model) {
+    pub fn geometry(&mut self, model: &Model) {
         match self.render_stage {
             RenderStage::Deferred => {}
             RenderStage::NeedsRedraw => {

--- a/lessons/12. Light III/src/main.rs
+++ b/lessons/12. Light III/src/main.rs
@@ -75,8 +75,8 @@ fn main() {
             let directional_light = DirectionalLight::new([x, 0.0, z, 1.0], [1.0, 1.0, 1.0]);
 
             system.start();
-            system.geometry(&mut cube1);
-            system.geometry(&mut cube2);
+            system.geometry(&cube1);
+            system.geometry(&cube2);
             system.ambient();
             system.directional(&directional_light);
             system.light_object(&directional_light);

--- a/lessons/12. Light III/src/system/system.rs
+++ b/lessons/12. Light III/src/system/system.rs
@@ -749,7 +749,7 @@ impl System {
         pool.from_data(uniform_data).unwrap()
     }
 
-    pub fn geometry(&mut self, model: &mut Model) {
+    pub fn geometry(&mut self, model: &Model) {
         match self.render_stage {
             RenderStage::Deferred => {}
             RenderStage::NeedsRedraw => {

--- a/lessons/9. Model Loading/src/model.rs
+++ b/lessons/9. Model Loading/src/model.rs
@@ -6,6 +6,7 @@
 use super::obj_loader::{Loader, NormalVertex};
 
 use nalgebra_glm::{identity, rotate_normalized_axis, translate, TMat4, TVec3};
+use std::cell::Cell;
 
 /// Holds our data for a renderable model, including the model matrix data
 ///
@@ -17,11 +18,18 @@ pub struct Model {
     data: Vec<NormalVertex>,
     translation: TMat4<f32>,
     rotation: TMat4<f32>,
+
+    // We might call multiple translation/rotation calls
+    // in between asking for the model matrix. This lets us
+    // only recreate the model matrices when needed.
+    // Use a Cell with the interior mutability pattern,
+    // so that it can be modified by methods that don't take &mut self
+    cache: Cell<Option<ModelMatrices>>,
+}
+
+#[derive(Copy, Clone)]
+struct ModelMatrices {
     model: TMat4<f32>,
-    // we might call multiple translation/rotation calls
-    // in between asking for the model matrix. This lets
-    // only recreate the model matrix when needed.
-    requires_update: bool,
 }
 
 pub struct ModelBuilder {
@@ -45,8 +53,7 @@ impl ModelBuilder {
             data: loader.as_normal_vertices(),
             translation: identity(),
             rotation: identity(),
-            model: identity(),
-            requires_update: false,
+            cache: Cell::new(None),
         }
     }
 
@@ -75,27 +82,32 @@ impl Model {
         self.data.clone()
     }
 
-    pub fn model_matrix(&mut self) -> TMat4<f32> {
-        if self.requires_update {
-            self.model = self.translation * self.rotation;
-            self.requires_update = false;
+    pub fn model_matrix(&self) -> TMat4<f32> {
+        if let Some(cache) = self.cache.get() {
+            return cache.model;
         }
-        self.model
+
+        // recalculate matrix
+        let model = self.translation * self.rotation;
+
+        self.cache.set(Some(ModelMatrices { model }));
+
+        model
     }
 
     pub fn rotate(&mut self, radians: f32, v: TVec3<f32>) {
         self.rotation = rotate_normalized_axis(&self.rotation, radians, &v);
-        self.requires_update = true;
+        self.cache.set(None);
     }
 
     pub fn translate(&mut self, v: TVec3<f32>) {
         self.translation = translate(&self.translation, &v);
-        self.requires_update = true;
+        self.cache.set(None);
     }
 
     /// Return the model's rotation to 0
     pub fn zero_rotation(&mut self) {
         self.rotation = identity();
-        self.requires_update = true;
+        self.cache.set(None);
     }
 }


### PR DESCRIPTION
In addition to being clear about which fields are actually cached, it also allows the `model_matrices` method to use `&self` instead of `&mut self` in the signature, and makes it clear that the caching is an internal concern of the Model.

This bubbles all the way to the public API for the System.  See the change to `System::geometry()`, for example.

It's also a good introduction to the concept of interior mutability in Rust. We may want to add a small section to the docs about this.

Also fix mention of obj_loader in section_9.md